### PR TITLE
Fix tensor shape comment

### DIFF
--- a/model_zoo/stage2/simple.py
+++ b/model_zoo/stage2/simple.py
@@ -46,12 +46,12 @@ class Net(nn.Module):
     def forward(self, s, g, m=None):
         if self.args.freeze_pretrained_model: self.basset_model.eval()
         
-        _, conv_out = self.basset_model(s)                                                    # batch_size x 1000
+        _, conv_out = self.basset_model(s)                                                    # batch_size x 4200
         
         if self.args.with_mean:
-            g = torch.cat((conv_out,g,m.view(-1,1)), 1)                                       # batch_size x (1000 + num_genes + 1)
+            g = torch.cat((conv_out,g,m.view(-1,1)), 1)                                       # batch_size x (4200 + num_genes + 1)
         else:
-            g = torch.cat([conv_out, g], dim = -1)                                            # batch_size x (1000 + num_genes)
+            g = torch.cat([conv_out, g], dim = -1)                                            # batch_size x (4200 + num_genes)
 
         g = F.dropout(F.relu(self.bn1(self.fc1(g))), p=self.args.dropout, training=self.training)  # batch_size x 1000
         g = F.dropout(F.relu(self.bn2(self.fc2(g))), p=self.args.dropout, training=self.training)  # batch_size x 1000


### PR DESCRIPTION
A small fix of the comments regarding the shape of outputs of some layers.

As mentioned in the comment in line 35 of the same file, "all stage1 models have dim 4200 for conv out", so the output shapes would in fact have dimension of 4200, not 1000.